### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/app/configurator/ADCConfigurator.js
+++ b/app/configurator/ADCConfigurator.js
@@ -550,7 +550,7 @@ ADCInfo.prototype.set = function set(data) {
      *       adcInfo.guid();
      *
      *       // Set the guid of the ADC
-     *       var uuid = require('node-uuid'');
+     *       var uuid = require('uuid'');
      *       adcInfo.guid(uuid.v4());
      *
      * @method guid

--- a/app/generator/ADCGenerator.js
+++ b/app/generator/ADCGenerator.js
@@ -4,7 +4,7 @@ var pathHelper  = require('path');
 var common      = require('../common/common.js');
 var preferences = require('../preferences/ADCPreferences.js');
 var wrench      = require('wrench');
-var uuid        = require('node-uuid');
+var uuid        = require('uuid');
 var errMsg      = common.messages.error;
 var successMsg  = common.messages.success;
 

--- a/docs/source/ADCConfigurator.html
+++ b/docs/source/ADCConfigurator.html
@@ -567,7 +567,7 @@ ADCInfo.prototype.set = function set(data) {
      *       adcInfo.guid();
      *
      *       // Set the guid of the ADC
-     *       var uuid = require(&#39;node-uuid&#39;&#39;);
+     *       var uuid = require(&#39;uuid&#39;&#39;);
      *       adcInfo.guid(uuid.v4());
      *
      * @method guid

--- a/docs/source/ADCGenerator.html
+++ b/docs/source/ADCGenerator.html
@@ -21,7 +21,7 @@ var pathHelper  = require(&#39;path&#39;);
 var common      = require(&#39;../common/common.js&#39;);
 var preferences = require(&#39;../preferences/ADCPreferences.js&#39;);
 var wrench      = require(&#39;wrench&#39;);
-var uuid        = require(&#39;node-uuid&#39;);
+var uuid        = require(&#39;uuid&#39;);
 var errMsg      = common.messages.error;
 var successMsg  = common.messages.success;
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "commander": "^1.1.1",
     "elementtree": "^0.1.6",
     "jszip": "^2.2.2",
-    "node-uuid": "^1.4.0",
+    "uuid": "^3.0.0",
     "wrench": "^1.5.1",
     "xml2js": "^0.2.7"
   },

--- a/spec/generator/ADCGeneratorSpec.js
+++ b/spec/generator/ADCGeneratorSpec.js
@@ -3,7 +3,7 @@ describe('ADCGenerator', function () {
     var fs              = require('fs'),
         wrench          = require('wrench'),
         format          = require('util').format,
-        uuid            = require('node-uuid'),
+        uuid            = require('uuid'),
         pathHelper      = require('path'),
         spies           = {},
         common,


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.